### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,7 +1,7 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.JwtParser;
@@ -20,8 +20,7 @@ public class User {
 
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact();
   }
 
   public static void assertAuth(String secret, String token) {
@@ -37,16 +36,15 @@ public class User {
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null;
     User user = null;
     try {
       Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
+      stmt = cxn.prepareStatement("select * from users where username = ? limit 1");
+      stmt.setString(1, un);
       System.out.println("Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");
@@ -58,6 +56,13 @@ public class User {
       e.printStackTrace();
       System.err.println(e.getClass().getName()+": "+e.getMessage());
     } finally {
+      try {
+        if (stmt != null) {
+          stmt.close();
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
       return user;
     }
   }


### PR DESCRIPTION
 ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado pelo GFT AI Impact Bot para 30170067c0d7dc1e44ab5c5474ef2cb405849f0b
Descrição: Atualiza o arquivo src/main/java/com/scalesec/vulnado/User.java para usar PreparedStatement em vez de Statement para consultas SQL. Isso ajuda a prevenir ataques de injeção de SQL.
Sumário:
src/main/java/com/scalesec/vulnado/User.java (modificado) - Atualiza o arquivo para usar PreparedStatement em vez de Statement para consultas SQL.
Recomendações:
Parece bom para mim.
Explicação de Vulnerabilidades:
A injeção de SQL é um tipo de ataque que permite que um invasor execute código SQL arbitrário em um banco de dados. Isso pode levar a uma variedade de problemas, incluindo roubo de dados, destruição de dados e negação de serviço.
Exemplo:
O seguinte código é vulnerável a ataques de injeção de SQL:

```
String query = "select * from users where username = '" + un + "' limit 1";
```

Se um invasor fornecer um valor para `un` que contenha caracteres especiais, como uma aspas simples (`'`), eles podem executar código SQL arbitrário no banco de dados. Por exemplo, o seguinte valor para `un` executaria a instrução SQL `DELETE FROM users`:

```
' OR 1=1; DELETE FROM users; --
```

Para evitar ataques de injeção de SQL, você deve usar PreparedStatements em vez de Statements para consultas SQL. PreparedStatements são mais seguros porque eles impedem que os invasores injetem código SQL arbitrário nas consultas.