### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,18 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.logging.Logger;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = Logger.getLogger(User.class.getName()); // Alterado por GFT AI Impact Bot
+  private String id; // Alterado por GFT AI Impact Bot
+  private String username; // Alterado por GFT AI Impact Bot
+  private String hashedPassword; // Alterado por GFT AI Impact Bot
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,10 +20,21 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() { // Incluido por GFT AI Impact Bot
+    return id;
+  }
+
+  public String getUsername() { // Incluido por GFT AI Impact Bot
+    return username;
+  }
+
+  public String getHashedPassword() { // Incluido por GFT AI Impact Bot
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact(); // Alterado por GFT AI Impact Bot
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +44,29 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null; // Alterado por GFT AI Impact Bot
     User user = null;
-    try {
-      Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+    try (Connection cxn = Postgres.connection()) { // Alterado por GFT AI Impact Bot
+      stmt = cxn.prepareStatement("select * from users where username = ? limit 1"); // Alterado por GFT AI Impact Bot
+      stmt.setString(1, un); // Incluido por GFT AI Impact Bot
+      LOGGER.info("Opened database successfully"); // Alterado por GFT AI Impact Bot
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id"); // Alterado por GFT AI Impact Bot
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
-      cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
-    } finally {
-      return user;
+      LOGGER.severe(e.getClass().getName()+": "+e.getMessage()); // Alterado por GFT AI Impact Bot
     }
+    return user; // Alterado por GFT AI Impact Bot
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 1136ea22e8e9de2f0655b8ba33514fb68e699612

**Descrição:** Este Pull Request apresenta uma série de alterações no arquivo User.java, principalmente visando aprimorar a segurança e a qualidade do código. As mudanças incluem a substituição de `Statement` por `PreparedStatement` para evitar SQL Injection, a adição de getters para os campos privados da classe User, a substituição de impressões de erros na saída padrão por logs e a melhoria no gerenciamento de conexões com o banco de dados.

**Sumario:**
- src/main/java/com/scalesec/vulnado/User.java (alterado)
  - Substituição de `Statement` por `PreparedStatement` para maior segurança contra SQL Injection
  - Adicionado getters para os campos privados da classe User
  - Substituição de `System.out.println` e `e.printStackTrace` por logs através da classe `Logger`
  - Melhoria no gerenciamento de conexões com o banco de dados através do uso de try-with-resources
  - Alteração da visibilidade de campos da classe User para privado

**Recomendações:** Sugiro que, durante a revisão, seja prestada atenção especial à substituição do `Statement` pelo `PreparedStatement` e à mudança na visibilidade dos campos da classe User. Além disso, é importante verificar se o uso do `Logger` está sendo feito corretamente e se o gerenciamento de conexões com o banco de dados foi aprimorado conforme esperado.

**Explicação de Vulnerabilidades:** A vulnerabilidade de SQL Injection foi mitigada com a substituição de `Statement` por `PreparedStatement`, que permite a inserção segura de valores em uma consulta SQL. Além disso, a visibilidade dos campos da classe User foi alterada para privado para garantir o encapsulamento correto, uma prática importante para a segurança e a manutenção do código. Outra vulnerabilidade potencial que foi mitigada é a exposição de informações sensíveis ou detalhes do sistema através de impressões na saída padrão, que foram substituídas por logs.